### PR TITLE
dynamic city code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    lalamove (0.1.1)
+    lalamove (0.1.2)
       activesupport (>= 5, < 7)
       awesome_print
       dry-struct (~> 1.4.0)
@@ -18,7 +18,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -29,21 +29,21 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
     docile (1.4.0)
     dotenv (2.7.6)
-    dry-configurable (0.12.1)
+    dry-configurable (0.13.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.5, >= 0.5.0)
-    dry-container (0.7.2)
+      dry-core (~> 0.6)
+    dry-container (0.9.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.5.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+    dry-core (0.7.1)
       concurrent-ruby (~> 1.0)
-    dry-inflector (0.2.0)
+    dry-inflector (0.2.1)
     dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
@@ -106,7 +106,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/lalamove/services/request_service.rb
+++ b/lib/lalamove/services/request_service.rb
@@ -48,7 +48,7 @@ module Lalamove
           'Content-Type': 'application/json',
           'Accept': 'application/json',
           'Authorization': "hmac #{Lalamove.configuration.token}:#{timestamp}:#{signature}",
-          'X-LLM-Country': 'BR_SAO',
+          'X-LLM-Country': Lalamove.configuration.city,
           'X-Request-ID': timestamp.to_s
         }
       end

--- a/lib/lalamove/version.rb
+++ b/lib/lalamove/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lalamove
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/lalamove/services/request_service_spec.rb
+++ b/spec/lalamove/services/request_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Lalamove::Services::RequestService do
       'Content-Type': 'application/json',
       Accept: 'application/json',
       Authorization: anything,
-      'X-LLM-Country': anything,
+      'X-LLM-Country': 'BR_SAO',
       'X-Request-ID': anything
     }
   end

--- a/spec/lalamove_spec.rb
+++ b/spec/lalamove_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Lalamove do
     end
 
     it 'returns the real version number' do
-      is_expected.to eql('0.1.1')
+      is_expected.to eql('0.1.2')
     end
   end
 


### PR DESCRIPTION
## Alterações:
Precisamos enviar o código da cidade de forma dinâmica para a Lalamove fazer entregas na região das novas filiais, atualmente no código está fixo para SP

A tabela de códigos de cidade da Lalamove pode ser encontrado no link: https://developers.lalamove.com/#service-types 

## Descreva brevemente as alterações introduzidas por este PR:
Alteração da configuração do código da cidade para que seja definido de forma dinâmica.



