### PR TITLE
Correção no retorno de errors no RequestService

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    lalamove (0.2.4)
+    lalamove (0.2.5)
       activesupport (>= 5, < 7)
       awesome_print
       dry-struct (~> 1.4.0)

--- a/lib/lalamove/services/request_service.rb
+++ b/lib/lalamove/services/request_service.rb
@@ -63,7 +63,7 @@ module Lalamove
         response(
           errors: result.reason_phrase,
           status: result.status,
-          message: parser(result.body)[:message]
+          message: parser(result.body)[:errors].first[:message]
         )
       end
     end

--- a/lib/lalamove/version.rb
+++ b/lib/lalamove/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lalamove
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/spec/lalamove/services/request_service_spec.rb
+++ b/spec/lalamove/services/request_service_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Lalamove::Services::RequestService do
           body: body,
           status: 422,
           success?: false,
-          reason_phrase: "Unprocessable Entity",
-          response_body: { errors: [{id: 'bar', message: 'Baz'}] }.to_json
+          reason_phrase: 'Unprocessable Entity',
+          response_body: { errors: [{ id: 'bar', message: 'Baz' }] }.to_json
         )
       end
 
@@ -74,7 +74,7 @@ RSpec.describe Lalamove::Services::RequestService do
       end
 
       it 'returns an array errors' do
-        expect(subject.errors).to eq(["Unprocessable Entity"])
+        expect(subject.errors).to eq(['Unprocessable Entity'])
       end
     end
   end

--- a/spec/lalamove/services/request_service_spec.rb
+++ b/spec/lalamove/services/request_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Lalamove::Services::RequestService do
     end
 
     context 'when status code different from 201' do
-      let(:body)    { '{"data":{"foo": "bar"}}' }
+      let(:body)    { '{"errors": [{"id": "bar", "message": "Baz"}]}' }
       let(:request) { double(post: result) }
 
       let(:result) do
@@ -60,8 +60,8 @@ RSpec.describe Lalamove::Services::RequestService do
           body: body,
           status: 422,
           success?: false,
-          reason_phrase: { data: { foo: 'bar' } },
-          response_body: { bar: 'Baz' }.to_json
+          reason_phrase: "Unprocessable Entity",
+          response_body: { errors: [{id: 'bar', message: 'Baz'}] }.to_json
         )
       end
 
@@ -69,8 +69,12 @@ RSpec.describe Lalamove::Services::RequestService do
         allow_any_instance_of(described_class).to receive(:connection).and_return(request)
       end
 
-      it 'returns an error' do
-        expect(subject.errors).to eq([JSON.parse(result.body, symbolize_names: true)])
+      it 'returns an message error' do
+        expect(subject.message).to eq('Baz')
+      end
+
+      it 'returns an array errors' do
+        expect(subject.errors).to eq(["Unprocessable Entity"])
       end
     end
   end

--- a/spec/lalamove_spec.rb
+++ b/spec/lalamove_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Lalamove do
     end
 
     it 'returns the real version number' do
-      is_expected.to eql('0.2.4')
+      is_expected.to eql('0.2.5')
     end
   end
 


### PR DESCRIPTION
## Alterações:
<!-- Importante deixar claro o que foi executado nesse PR -->
- [X] Com a atualização da gem para conexão com a lalamove v3, notamos que a maneira de retorno de possiveis errors na request mudou. Anteriormente era retornado uma response com a mensagem de error `{"message":  "Error"}`. Porém agora é retornado um json com o seguinte formato: {"errors": [{"id": "ID_ERROR", "message": "MESSAGE_ERROR"}]}. Fazendo assim com que o atributo message no response de error ficar como nil.
